### PR TITLE
Fix an issue when adding new rope climbs to the distribution

### DIFF
--- a/src/components/distributions/RouteDistributionChart.jsx
+++ b/src/components/distributions/RouteDistributionChart.jsx
@@ -158,8 +158,6 @@ const addNewClimb = () => {
     setTimeout(() => { setCurrentSection(1)}, 500)
   }, []);
 
-
-  console.log(sectionDistribution)
   return (
     <Box sx={{ m: '0 auto', mt: '5rem', width: '95rem' }}>
       <Box sx={{ mx: 'auto', position: 'fixed', top: '4rem', bgcolor: theme => theme.palette.common.white, width: "90%", zIndex: 999}}>


### PR DESCRIPTION
Before, adding a new rope climbing to an empty section would not work because of the logic that set the station number was based on the last climb in the current section.  It would look for a value in something that didn't exist and wouldn't be able to do anything from there.  Now there is a fallback if there are no climbs to pull info from.